### PR TITLE
Prevent adding custom events twice

### DIFF
--- a/src/Traits/PivotEventTrait.php
+++ b/src/Traits/PivotEventTrait.php
@@ -20,8 +20,7 @@ trait PivotEventTrait
                 'pivotAttaching', 'pivotAttached',
                 'pivotDetaching', 'pivotDetached',
                 'pivotUpdating', 'pivotUpdated',
-            ],
-            $this->observables
+            ]
         );
     }
 


### PR DESCRIPTION
The parent::getObservableEvents() method already merge custom events ($this->observables) with eloquent events.